### PR TITLE
Add group information to TripRecord

### DIFF
--- a/src/services/tripRecords.service.js
+++ b/src/services/tripRecords.service.js
@@ -13,7 +13,9 @@ export async function createTripRecord(userId, data) {
 }
 
 export async function getMyTripRecordById(userId, id) {
-    return TripRecord.findOne({ _id: id, userId });
+    // groupId를 이용해 그룹의 name, color 필드를 함께 가져옵니다.
+    return TripRecord.findOne({ _id: id, userId })
+        .populate({ path: 'groupId', select: 'name color' });
 }
 
 export async function updateMyTripRecord(userId, id, body) {
@@ -30,7 +32,12 @@ export async function deleteMyTripRecord(userId, id) {
 
 export async function listMyTripRecords(userId, filter, page, limit) {
     const [items, total] = await Promise.all([
-        TripRecord.find({ userId, ...filter }).sort({ date: -1 }).skip((page - 1) * limit).limit(limit),
+        // .populate()를 추가하여 각 기록의 그룹 정보를 함께 가져옵니다.
+        TripRecord.find({ userId, ...filter })
+            .populate({ path: 'groupId', select: 'name color' }) // groupId로 Group의 name, color를 찾습니다.
+            .sort({ date: -1 })
+            .skip((page - 1) * limit)
+            .limit(limit),
         TripRecord.countDocuments({ userId, ...filter })
     ]);
     return { items, total };


### PR DESCRIPTION
```
### Summary of Changes

- Modified TripRecord retrieval to include group `name` and `color` using `populate`.
- Enhanced logic to ensure paginated TripRecord lists include group information.

### Impact on Existing Code

- Group-related data is now part of TripRecord responses